### PR TITLE
Grunt template processing for config file path

### DIFF
--- a/tasks/testacularServer.coffee
+++ b/tasks/testacularServer.coffee
@@ -14,6 +14,7 @@ module.exports = (grunt) ->
     # default values
     @data.options ?= {}
     @data.options.keepalive ?= false
+    @data.configFile = grunt.template.process @data.configFile if @data.configFile
       
     # start the server
     server.start @data, (exitCode) ->

--- a/tasks/testacularServer.js
+++ b/tasks/testacularServer.js
@@ -11,6 +11,9 @@ module.exports = function(grunt) {
     if ((_ref1 = (_base1 = this.data.options).keepalive) == null) {
       _base1.keepalive = false;
     }
+    if (this.data.configFile) {
+      this.data.configFile = grunt.template.process(this.data.configFile);
+    }
     server.start(this.data, function(exitCode) {
       if (exitCode > 0) {
         return done(false);


### PR DESCRIPTION
Hi,

found it useful to resolve variables for config file path so something like this
`configFile:'<%= pkg.config %>/testacular.conf.js'`
would work.

Thx for starting the project and cheers,
Catty
