### PR TITLE
Fixes the issue where you couldn't run any grunt tasks after the test task.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "testacular": ">=0.4.0"
+    "testacular": ">=0.5.7"
   },
   "devDependencies": {
     "grunt": "~0.3.17",

--- a/tasks/testacularServer.coffee
+++ b/tasks/testacularServer.coffee
@@ -18,7 +18,7 @@ module.exports = (grunt) ->
       
     # start the server
     server.start @data, (exitCode) ->
-      done(false) if exitCode > 0
+      done(exitCode == 0)
     
     
     # unless the keepalive option is set we are finished

--- a/tasks/testacularServer.js
+++ b/tasks/testacularServer.js
@@ -1,4 +1,3 @@
-
 module.exports = function(grunt) {
   var server;
   server = require('testacular').server;
@@ -15,9 +14,7 @@ module.exports = function(grunt) {
       this.data.configFile = grunt.template.process(this.data.configFile);
     }
     server.start(this.data, function(exitCode) {
-      if (exitCode > 0) {
-        return done(false);
-      }
+      return done(exitCode === 0);
     });
     if (!this.data.options.keepalive) {
       return done();


### PR DESCRIPTION
Update the version of testacular in package.json.  It needed to be updated because server.start doesn't take a callback as the second parameter in later versions.  Also, make sure that done always gets called with the correct exit code.
